### PR TITLE
Add flight tracker sample app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
 # TimFinder
+
+This project provides a simple flight tracking web service. It consists of a
+Python/Flask backend that queries the [AviationStack](https://aviationstack.com/)
+API for live flight data and a small front-end using Leaflet to display the
+plane's position on a world map.
+
+## Backend
+
+The backend lives in `backend/` and exposes a single endpoint:
+
+```
+GET /api/flight/<flight_number>
+```
+
+The endpoint requires an API key for AviationStack. Set the environment variable
+`AVIATIONSTACK_KEY` before running the server.
+
+### Install dependencies
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r backend/requirements.txt
+```
+
+### Run
+
+```bash
+export AVIATIONSTACK_KEY=your_key_here
+python backend/app.py
+```
+
+## Frontend
+
+Open `frontend/index.html` in a browser. Enter a flight number and the page will
+request location data from the backend and place a marker on an interactive
+map.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,37 @@
+import os
+import requests
+from flask import Flask, jsonify, abort
+
+app = Flask(__name__)
+
+API_KEY = os.environ.get("AVIATIONSTACK_KEY")
+API_BASE = "http://api.aviationstack.com/v1/flights"
+
+@app.route('/api/flight/<flight_number>')
+def flight_info(flight_number):
+    if not API_KEY:
+        abort(500, description="API key not configured")
+    params = {
+        'access_key': API_KEY,
+        'flight_iata': flight_number
+    }
+    resp = requests.get(API_BASE, params=params, timeout=10)
+    if resp.status_code != 200:
+        abort(resp.status_code)
+    data = resp.json()
+    flights = data.get('data', [])
+    if not flights:
+        abort(404, description="Flight not found")
+    # Use the first flight entry
+    flight = flights[0]
+    position = flight.get('live', {})
+    if not position:
+        abort(404, description="No live data for this flight")
+    return jsonify({
+        'latitude': position.get('latitude'),
+        'longitude': position.get('longitude'),
+        'altitude': position.get('altitude')
+    })
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Flight Tracker</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <style>
+        #map { height: 500px; }
+    </style>
+</head>
+<body>
+    <h1>Flight Tracker</h1>
+    <form id="flight-form">
+        <input type="text" id="flight-number" placeholder="Enter flight number" required>
+        <button type="submit">Track</button>
+    </form>
+    <div id="map"></div>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,0 +1,27 @@
+const form = document.getElementById('flight-form');
+const mapDiv = document.getElementById('map');
+let map;
+
+form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const flightNumber = document.getElementById('flight-number').value;
+    try {
+        const resp = await fetch(`/api/flight/${flightNumber}`);
+        if (!resp.ok) {
+            throw new Error('Flight not found');
+        }
+        const data = await resp.json();
+        const { latitude, longitude } = data;
+        if (!map) {
+            map = L.map('map').setView([latitude, longitude], 6);
+            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                maxZoom: 18,
+                attribution: '&copy; OpenStreetMap contributors'
+            }).addTo(map);
+        }
+        map.setView([latitude, longitude], 6);
+        L.marker([latitude, longitude]).addTo(map);
+    } catch (err) {
+        alert(err.message);
+    }
+});


### PR DESCRIPTION
## Summary
- add a simple Flask backend that queries the AviationStack API
- add front-end with Leaflet map to visualize flight location
- update README with setup instructions

## Testing
- `python -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_685937a3d95c8322adc117b116c707a6